### PR TITLE
Add display of previous search results to edit_queue page

### DIFF
--- a/queues/templates/queues/edit_queue.html
+++ b/queues/templates/queues/edit_queue.html
@@ -21,7 +21,7 @@
     {% csrf_token %}
     <span>
         <label for="searchQuery">Search:</label>
-        <input type="text" id="searchQuery" name="searchQuery" placeholder="Wonderwall">
+        <input type="text" id="searchQuery" name="searchQuery" value="{{recent_search}}">
     </span>
     <button id="searchButton" type="submit" class="btn btn-lg">Search</button>
 </form>

--- a/queues/views.py
+++ b/queues/views.py
@@ -38,12 +38,20 @@ def edit_queue(request, queue_id):
     queue = Queue.find_queue(queue_id)
     request.session["queue"] = queue.serialize()
     user = request.user
-    recent_search = request.POST.get("searchQuery", "")
-    search_results = []
     is_owner = queue.owner == user
-    if recent_search:
+    last_search = request.session.get("last_search_request","")
+    if request.method == "POST":
+        recent_search = request.POST.get("searchQuery", "")
         yt = YT(user)
         search_results = yt.search_videos(recent_search)
+        request.session["last_search_request"] = recent_search
+    elif last_search:
+        recent_search = last_search
+        yt = YT(user)
+        search_results = yt.search_videos(last_search)
+    else:
+        recent_search = ""
+        search_results = []
     entry_form = EntryForm()
     entries = Entry.objects.all().filter(queue=queue.id)
     context = {


### PR DESCRIPTION
The commit message is different from git because I had forgotten I did this before I took my lunch break.

The edit queue page now displays the results from the previous search. This is done by making a query to the data base when the page comes back from adding an entry to the queue.

As it is, this will be carried from queue to queue, so when you go from one queue to another, it will have the old search results. This is a minor issue that isn't hard to fix but maybe annoying.